### PR TITLE
Fix badge primary variant CSS variable names

### DIFF
--- a/app/assets/stylesheets/badge.css
+++ b/app/assets/stylesheets/badge.css
@@ -56,8 +56,8 @@
 
 /* Primary variant - brand color */
 [data-component="badge"][data-variant="primary"] {
-  background-color: var(--primary-color);
-  color: var(--primary-foreground-color);
+  background-color: var(--primary);
+  color: var(--primary-foreground);
 }
 
 [data-component="badge"][data-variant="primary"]:hover {


### PR DESCRIPTION
The primary badge variant in `badge.css` references `--primary-color` and `--primary-foreground-color` (lines 59-60), but the theme template generated by the installer defines `--primary` and `--primary-foreground`.

Every other variant in the same file uses the short names correctly:

| Variant | Background var | Color var |
|---------|---------------|-----------|
| default | `--muted` | `--muted-foreground` |
| **primary** | **`--primary-color`** | **`--primary-foreground-color`** |
| secondary | `--secondary` | `--secondary-foreground` |
| destructive | `--destructive` | `--destructive-foreground` |
| success | `--success` | `--success-foreground` |
| warning | `--warning` | `--warning-foreground` |

This causes the primary badge to render with no visible background or text.

### The Fix

```diff
[data-component="badge"][data-variant="primary"] {
-  background-color: var(--primary-color);
-  color: var(--primary-foreground-color);
+  background-color: var(--primary);
+  color: var(--primary-foreground);
}
```
