### PR TITLE
Fix/set default icon for trigger

### DIFF
--- a/app/views/components/sidebar/_trigger.html.erb
+++ b/app/views/components/sidebar/_trigger.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (icon_name: :panel_left, css_classes: "", **html_options) %>
+<%# locals: (icon_name: :left_panel, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     sidebar_part: :trigger,
     controller: "sidebar-trigger",

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -117,7 +117,7 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| icon_name | Symbol | :panel_left | Icon name for toggle button |
+| icon_name | Symbol | :left_panel | Icon name for toggle button |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 


### PR DESCRIPTION
Fix sidebar/trigger missing default for icon_name

Set `icon_name: :left_panel` as default to prevent ActionView::StrictLocalsError when using the component without the parameter. Added a Trigger section to the documentation with a parameter table.

Issue reported at #5 
