### PR TITLE
Fix form error text using wrong CSS variable

### DIFF
--- a/app/assets/stylesheets/form.css
+++ b/app/assets/stylesheets/form.css
@@ -532,7 +532,7 @@
    =================================================================== */
 [data-form-part="error"] {
   @apply text-sm font-medium;
-  color: var(--destructive);
+  color: var(--destructive-foreground);
 }
 
 /* Rails error wrapper compatibility */


### PR DESCRIPTION
Error text was using `--destructive` (pale background color) instead of `--destructive-foreground`, making error messages nearly invisible.