### PR TITLE
Fix date picker and calendar locale handling

### DIFF
--- a/app/javascript/controllers/calendar_controller.js
+++ b/app/javascript/controllers/calendar_controller.js
@@ -72,7 +72,8 @@ export default class extends Controller {
 
     // Update caption
     if (caption) {
-      caption.textContent = firstOfMonth.toLocaleDateString(undefined, { month: 'long', year: 'numeric' })
+      const locale = document.documentElement.lang || undefined
+      caption.textContent = firstOfMonth.toLocaleDateString(locale, { month: 'long', year: 'numeric' })
     }
 
     // Calculate start of calendar grid

--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -176,7 +176,8 @@ export default class extends Controller {
         ? { month: "short", day: "numeric", year: "numeric" }
         : { weekday: "long", month: "long", day: "numeric", year: "numeric" }
 
-      return date.toLocaleDateString(undefined, options)
+      const locale = document.documentElement.lang || undefined
+      return date.toLocaleDateString(locale, options)
     } catch {
       return dateStr
     }

--- a/app/views/components/_calendar.html.erb
+++ b/app/views/components/_calendar.html.erb
@@ -49,10 +49,11 @@
   # Build weeks array
   weeks = (calendar_start..calendar_end).each_slice(7).to_a
 
-  # Weekday names
+  # Weekday names (localized)
+  abbr_day_names = I18n.t('date.abbr_day_names')
   weekday_names = week_starts_on == :monday ?
-    %w[Mo Tu We Th Fr Sa Su] :
-    %w[Su Mo Tu We Th Fr Sa]
+    abbr_day_names.rotate(1) :
+    abbr_day_names
 
   merged_data = (html_options.delete(:data) || {}).merge(
     controller: "calendar",


### PR DESCRIPTION
Use HTML lang attribute and Rails I18n instead of browser default locale for date formatting in calendar caption, date picker display, and weekday headers.