### PR TITLE
Improve Hotwire compatibility and fix yield bug in partials

### DIFF
--- a/app/assets/stylesheets/sidebar.css
+++ b/app/assets/stylesheets/sidebar.css
@@ -23,6 +23,18 @@
   transition: none !important;
 }
 
+/* Prevent layout shift before Stimulus initializes.
+   The server renders collapsible="offcanvas" (gap=0) but JS immediately
+   sets collapsible="none" (gap=sidebar-width) for expanded desktop sidebars.
+   This rule keeps the gap at the correct width during loading so the main
+   content doesn't jump from left to right. Desktop-only — on mobile JS
+   forces the sidebar closed and the gap should stay at 0. */
+@media (min-width: 768px) {
+  [data-sidebar-part="root"].sidebar-loading[data-state="expanded"] [data-sidebar-part="gap"] {
+    width: var(--sidebar-width);
+  }
+}
+
 /* ===== Sidebar Gap (creates space on desktop) ===== */
 [data-sidebar-part="gap"] {
   @apply relative bg-transparent;

--- a/app/helpers/maquina_components/toast_helper.rb
+++ b/app/helpers/maquina_components/toast_helper.rb
@@ -15,9 +15,9 @@ module MaquinaComponents
   #   <%= toast :error, "Save failed", description: "Please check your connection." %>
   #
   # @example Toast with action
-  #   <%= toast :info, "New version available" do %>
+  #   <%= toast :info, "New version available", content: capture { %>
   #     <%= render "components/toast/action", label: "Refresh", href: root_path %>
-  #   <% end %>
+  #   <% } %>
   #
   module ToastHelper
     # Flash type to toast variant mapping
@@ -55,15 +55,14 @@ module MaquinaComponents
     # @param title [String] Toast title
     # @param description [String, nil] Optional description
     # @param options [Hash] Additional options passed to the toast partial
-    # @yield Optional block for custom content (e.g., action button)
+    # @param content [String, nil] HTML content via `capture` (e.g., action button)
     # @return [String] HTML-safe toast element
-    def toast(variant, title, description: nil, **options, &block)
+    def toast(variant, title, description: nil, **options)
       render "components/toast",
         variant: variant,
         title: title,
         description: description,
-        **options,
-        &block
+        **options
     end
 
     # Render a success toast
@@ -71,8 +70,8 @@ module MaquinaComponents
     # @param title [String] Toast title
     # @param options [Hash] Additional options
     # @return [String] HTML-safe toast element
-    def toast_success(title, **options, &block)
-      toast(:success, title, **options, &block)
+    def toast_success(title, **options)
+      toast(:success, title, **options)
     end
 
     # Render an error toast
@@ -80,8 +79,8 @@ module MaquinaComponents
     # @param title [String] Toast title
     # @param options [Hash] Additional options
     # @return [String] HTML-safe toast element
-    def toast_error(title, **options, &block)
-      toast(:error, title, **options, &block)
+    def toast_error(title, **options)
+      toast(:error, title, **options)
     end
 
     # Render a warning toast
@@ -89,8 +88,8 @@ module MaquinaComponents
     # @param title [String] Toast title
     # @param options [Hash] Additional options
     # @return [String] HTML-safe toast element
-    def toast_warning(title, **options, &block)
-      toast(:warning, title, **options, &block)
+    def toast_warning(title, **options)
+      toast(:warning, title, **options)
     end
 
     # Render an info toast
@@ -98,8 +97,8 @@ module MaquinaComponents
     # @param title [String] Toast title
     # @param options [Hash] Additional options
     # @return [String] HTML-safe toast element
-    def toast_info(title, **options, &block)
-      toast(:info, title, **options, &block)
+    def toast_info(title, **options)
+      toast(:info, title, **options)
     end
 
     private

--- a/app/javascript/controllers/date_picker_controller.js
+++ b/app/javascript/controllers/date_picker_controller.js
@@ -28,12 +28,35 @@ export default class extends Controller {
   }
 
   connect() {
+    this.boundTeardown = this.teardown.bind(this)
+
     this.setupPopoverEvents()
     this.updateDisplay()
+    document.addEventListener("turbo:before-cache", this.boundTeardown)
   }
 
   disconnect() {
     this.teardownPopoverEvents()
+    document.removeEventListener("turbo:before-cache", this.boundTeardown)
+  }
+
+  /**
+   * Reset to closed state before Turbo caches the page
+   */
+  teardown() {
+    if (this.hasPopoverTarget) {
+      try {
+        if (this.popoverTarget.matches(":popover-open")) {
+          this.popoverTarget.hidePopover()
+        }
+      } catch {
+        // Popover API not supported
+      }
+    }
+
+    if (this.hasTriggerTarget) {
+      this.triggerTarget.setAttribute("aria-expanded", "false")
+    }
   }
 
   /**

--- a/app/views/components/_dropdown_menu.html.erb
+++ b/app/views/components/_dropdown_menu.html.erb
@@ -1,8 +1,9 @@
-<%# locals: (css_classes: "", **html_options) %>
+<%# locals: (auto_close: false, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     component: "dropdown-menu",
     controller: "dropdown-menu"
   ) %>
+<% merged_data["dropdown-menu-auto-close-value"] = true if auto_close %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
   <%= yield %>

--- a/app/views/components/_sidebar.html.erb
+++ b/app/views/components/_sidebar.html.erb
@@ -1,5 +1,5 @@
 <%# locals: (id: nil, state: :collapsed, collapsible: :offcanvas, variant: :inset, side: :left, css_classes: "", **html_options) %>
-<% random_id = id || "sidebar-#{SecureRandom.hex(6)}"
+<% stable_id = id || "sidebar-#{side}"
   
   merged_data = (html_options.delete(:data) || {}).merge(
     sidebar_part: :root,
@@ -11,16 +11,16 @@
   ) %>
 
 <aside
-  id="<%= random_id %>"
+  id="<%= stable_id %>"
   class="group peer sidebar-loading <%= css_classes %>"
   <%= tag.attributes(data: merged_data, **html_options) %>
 >
   <%# Sidebar gap (creates space for sidebar on desktop) %>
-  <div id="<%= random_id %>-gap" data-sidebar-part="gap"></div>
+  <div id="<%= stable_id %>-gap" data-sidebar-part="gap"></div>
 
   <%# Mobile backdrop overlay %>
   <div
-    id="<%= random_id %>-overlay"
+    id="<%= stable_id %>-overlay"
     data-sidebar-part="backdrop"
     data-sidebar-target="backdrop"
     data-action="click->sidebar#backdropClick"
@@ -28,12 +28,12 @@
 
   <%# Sidebar container (fixed positioned) %>
   <div
-    id="<%= random_id %>-container"
+    id="<%= stable_id %>-container"
     data-sidebar-part="container"
     data-sidebar-target="container"
   >
     <%# Inner sidebar content wrapper %>
-    <div id="<%= random_id %>-inner" data-sidebar-part="inner">
+    <div id="<%= stable_id %>-inner" data-sidebar-part="inner">
       <%= yield %>
     </div>
   </div>

--- a/app/views/components/_toast.html.erb
+++ b/app/views/components/_toast.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (variant: :default, title: nil, description: nil, icon: nil, duration: 5000, dismissible: true, css_classes: "", **html_options) %>
+<%# locals: (variant: :default, title: nil, description: nil, icon: nil, duration: 5000, dismissible: true, content: nil, css_classes: "", **html_options) %>
 <%
   # Auto-select icon based on variant if not provided
   default_icons = {
@@ -39,7 +39,7 @@
       <%= render "components/toast/description", text: description %>
     <% end %>
 
-    <%= yield if block_given? %>
+    <%= content if content %>
   </div>
 
   <% if dismissible %>

--- a/app/views/components/_toaster.html.erb
+++ b/app/views/components/_toaster.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (position: :bottom_right, css_classes: "", **html_options) %>
+<%# locals: (position: :bottom_right, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     component: :toaster,
     controller: "toaster",
@@ -13,5 +13,5 @@
       class: css_classes.presence,
       data: merged_data,
       **html_options do %>
-  <%= yield if block_given? %>
+  <%= content if content %>
 <% end %>

--- a/app/views/components/alert/_description.html.erb
+++ b/app/views/components/alert/_description.html.erb
@@ -1,6 +1,6 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(alert_part: :description) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/alert/_title.html.erb
+++ b/app/views/components/alert/_title.html.erb
@@ -1,6 +1,6 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(alert_part: :title) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/card/_description.html.erb
+++ b/app/views/components/card/_description.html.erb
@@ -1,6 +1,6 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(card_part: :description) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/card/_title.html.erb
+++ b/app/views/components/card/_title.html.erb
@@ -1,9 +1,9 @@
-<%# locals: (text: nil, size: :default, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, size: :default, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     card_part: :title,
     size: (size == :sm ? :sm : nil)
   ).compact %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/combobox/_label.html.erb
+++ b/app/views/components/combobox/_label.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     combobox_part: "label"
   ) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/sidebar/_provider.html.erb
+++ b/app/views/components/sidebar/_provider.html.erb
@@ -1,4 +1,4 @@
-<%# locals: (default_open: true, variant: :inset, css_classes: "", cookie_name: "sidebar_state", keyboard_shortcut: "b", **html_options) %>
+<%# locals: (id: nil, default_open: true, variant: :inset, css_classes: "", cookie_name: "sidebar_state", keyboard_shortcut: "b", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     component: :sidebar,
     variant: variant,
@@ -11,6 +11,6 @@
     action: "keydown.meta+#{keyboard_shortcut}@window->sidebar#toggleWithKeyboard keydown.ctrl+#{keyboard_shortcut}@window->sidebar#toggleWithKeyboard"
   ) %>
 
-<%= content_tag :div, class: css_classes, data: merged_data, **html_options do %>
+<%= content_tag :div, id: id || "sidebar-provider", class: css_classes, data: merged_data, **html_options do %>
   <%= yield %>
 <% end %>

--- a/app/views/components/toast/_description.html.erb
+++ b/app/views/components/toast/_description.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     toast_part: "description"
   ) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/app/views/components/toast/_title.html.erb
+++ b/app/views/components/toast/_title.html.erb
@@ -1,8 +1,8 @@
-<%# locals: (text: nil, css_classes: "", **html_options) %>
+<%# locals: (text: nil, content: nil, css_classes: "", **html_options) %>
 <% merged_data = (html_options.delete(:data) || {}).merge(
     toast_part: "title"
   ) %>
 
 <%= content_tag :div, class: css_classes.presence, data: merged_data, **html_options do %>
-  <%= text || yield %>
+  <%= text || content %>
 <% end %>

--- a/docs/alert.md
+++ b/docs/alert.md
@@ -63,7 +63,8 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Title text, or use block |
+| text | String | nil | Title text |
+| content | String | nil | HTML content via `capture` |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 
@@ -71,6 +72,7 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Description text, or use block |
+| text | String | nil | Description text |
+| content | String | nil | HTML content via `capture` |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |

--- a/docs/card.md
+++ b/docs/card.md
@@ -96,7 +96,8 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Title text, or use block |
+| text | String | nil | Title text |
+| content | String | nil | HTML content via `capture` |
 | size | Symbol | :default | :default or :sm |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
@@ -105,7 +106,8 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Description text, or use block |
+| text | String | nil | Description text |
+| content | String | nil | HTML content via `capture` |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 

--- a/docs/combobox.md
+++ b/docs/combobox.md
@@ -41,14 +41,14 @@
 ```erb
 <%%= render "components/combobox/list" do %>
   <%%= render "components/combobox/group" do %>
-    <%%= render "components/combobox/label" do %>Backend<%% end %>
+    <%%= render "components/combobox/label", text: "Backend" %>
     <%%= render "components/combobox/option", value: "ruby" do %>Ruby<%% end %>
   <%% end %>
 
   <%%= render "components/combobox/separator" %>
 
   <%%= render "components/combobox/group" do %>
-    <%%= render "components/combobox/label" do %>Frontend<%% end %>
+    <%%= render "components/combobox/label", text: "Frontend" %>
     <%%= render "components/combobox/option", value: "js" do %>JavaScript<%% end %>
   <%% end %>
 <%% end %>
@@ -125,7 +125,8 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Label text, or use block |
+| text | String | nil | Label text |
+| content | String | nil | HTML content via `capture` |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 

--- a/docs/date_picker.md
+++ b/docs/date_picker.md
@@ -81,3 +81,7 @@
 | required | Boolean | false | Mark input as required |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
+
+## Turbo Drive
+
+The date picker controller automatically closes the popover before Turbo caches the page. No configuration is needed — pressing the browser back button will always show the date picker in its closed state.

--- a/docs/dropdown_menu.md
+++ b/docs/dropdown_menu.md
@@ -72,6 +72,7 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| auto_close | Boolean | false | Close on item click before Turbo navigates |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 
@@ -136,3 +137,24 @@
 | text | String | nil | Shortcut text, or use block |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
+
+## Turbo Drive
+
+The dropdown menu controller automatically resets to a closed state before Turbo caches the page. This prevents stale open menus from appearing when the user navigates back.
+
+### Auto Close for Navigation Menus
+
+When a dropdown contains navigation links, use `auto_close: true` so the menu closes immediately on item click — before Turbo starts navigating:
+
+```erb
+<%%= render "components/dropdown_menu", auto_close: true do %>
+  <%%= render "components/dropdown_menu/trigger" do %>Navigate<%% end %>
+
+  <%%= render "components/dropdown_menu/content" do %>
+    <%%= render "components/dropdown_menu/item", href: dashboard_path do %>Dashboard<%% end %>
+    <%%= render "components/dropdown_menu/item", href: settings_path do %>Settings<%% end %>
+  <%% end %>
+<%% end %>
+```
+
+Without `auto_close`, the dropdown stays open during navigation and Turbo may cache the page with it visible. With `auto_close: true`, clicking an item closes the dropdown instantly, so the cached snapshot is always clean.

--- a/docs/sidebar.md
+++ b/docs/sidebar.md
@@ -69,6 +69,7 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
+| id | String | "sidebar-provider" | Element ID for stable morph matching |
 | default_open | Boolean | true | Initial open state |
 | variant | Symbol | :inset | Visual variant |
 | cookie_name | String | "sidebar_state" | Cookie for persistence |
@@ -141,3 +142,39 @@
 | sidebar_state(cookie_name) | Returns :expanded or :collapsed |
 | sidebar_open?(cookie_name) | Returns true if expanded |
 | sidebar_closed?(cookie_name) | Returns true if collapsed |
+
+## Turbo Drive
+
+The sidebar controller integrates with Turbo Drive to maintain correct state across navigations:
+
+- **Cache teardown:** On mobile, the sidebar closes and the backdrop is hidden before Turbo caches the page. Pressing back never shows a stale open sidebar or scroll-locked body.
+- **Morph awareness:** When using `turbo_refresh_method_tag :morph`, the sidebar re-reads its cookie to preserve the desktop toggle state and forces closed on mobile after a morph refresh.
+- **Desktop persistence:** The sidebar state is stored in a cookie, so it survives full page loads and Turbo navigations without extra configuration.
+
+### Stable IDs
+
+The sidebar generates deterministic IDs based on its `side:` parameter (`sidebar-left`, `sidebar-right`) instead of random IDs. This allows idiomorph to match old and new elements across morph renders, preventing the sidebar from being destroyed and recreated.
+
+The provider div also receives a stable ID (`sidebar-provider`) for the same reason.
+
+If you render multiple sidebars on the same side, pass explicit `id:` parameters to avoid collisions:
+
+```erb
+<%%= render "components/sidebar/provider", id: "sidebar-main" do %>
+  <%%= render "components/sidebar", id: "sidebar-nav", side: :left do %>
+    ...
+  <%% end %>
+<%% end %>
+```
+
+### Morph Compatibility
+
+During a Turbo morph, the server-rendered `data-sidebar-open-value` may carry a stale value (e.g., from a broadcast where the server has no access to the browser cookie). The controller treats the browser cookie as the source of truth:
+
+1. Before morph updates attributes, the controller sets an internal guard flag.
+2. When idiomorph overwrites `data-sidebar-open-value`, the Stimulus value callback is skipped — preventing the stale server value from overwriting the cookie.
+3. After morph completes, the controller reads the cookie, reasserts the correct state, and removes the `sidebar-loading` class that morph re-adds from server HTML.
+
+### Turbo Frames
+
+The sidebar works inside Turbo Frames because stable IDs enable clean Stimulus disconnect/reconnect cycles. On reconnection, `initialize()` re-reads the cookie, so the sidebar always reflects the latest client-side state.

--- a/docs/toast.md
+++ b/docs/toast.md
@@ -46,9 +46,10 @@
 ```erb
 <%%= render "components/toast",
   title: "Event Created",
-  description: "Your event has been scheduled." do %>
+  description: "Your event has been scheduled.",
+  content: capture { %>
   <%%= render "components/toast/action", label: "Undo", href: "#" %>
-<%% end %>
+<%% } %>
 ```
 
 ## API Reference
@@ -63,6 +64,7 @@
 | icon | Symbol | nil | Icon name (auto-selected by variant) |
 | duration | Integer | 5000 | Auto-dismiss time in ms |
 | dismissible | Boolean | true | Show close button |
+| content | String | nil | HTML content via `capture` (e.g., action buttons) |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 
@@ -70,7 +72,8 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Title text (or use block) |
+| text | String | nil | Title text |
+| content | String | nil | HTML content via `capture` |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 
@@ -78,7 +81,24 @@
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| text | String | nil | Description text (or use block) |
+| text | String | nil | Description text |
+| content | String | nil | HTML content via `capture` |
+| css_classes | String | "" | Additional CSS classes |
+| html_options | Hash | {} | Additional HTML attributes |
+
+### Toaster
+
+The toaster is the container that holds and positions toast notifications. Place it once in your layout.
+
+```erb
+<%%= render "components/toaster", position: :bottom_right,
+      content: toast_flash_messages %>
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| position | Symbol | :bottom_right | :top_left, :top_right, :bottom_left, :bottom_right |
+| content | String | nil | Pre-rendered toasts (e.g., flash messages) |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
 
@@ -91,3 +111,14 @@
 | method | Symbol | nil | HTTP method for Turbo |
 | css_classes | String | "" | Additional CSS classes |
 | html_options | Hash | {} | Additional HTML attributes |
+
+### Helper Methods
+
+| Method | Description |
+|--------|-------------|
+| toast_flash_messages(exclude: []) | Renders all flash messages as toasts |
+| toast(variant, title, **options) | Renders a single toast |
+| toast_success(title, **options) | Shorthand for success variant |
+| toast_error(title, **options) | Shorthand for error variant |
+| toast_warning(title, **options) | Shorthand for warning variant |
+| toast_info(title, **options) | Shorthand for info variant |

--- a/test/dummy/app/views/layouts/application.html.erb
+++ b/test/dummy/app/views/layouts/application.html.erb
@@ -275,8 +275,7 @@
     <% end %>
 
     <%# Toast notifications container %>
-    <%= render "components/toaster", position: :bottom_right do %>
-      <%= toast_flash_messages %>
-    <% end %>
+    <%= render "components/toaster", position: :bottom_right,
+          content: toast_flash_messages %>
   </body>
 </html>

--- a/test/dummy/app/views/previews/combobox/with_groups.html.erb
+++ b/test/dummy/app/views/previews/combobox/with_groups.html.erb
@@ -7,7 +7,7 @@
 
       <%= render "components/combobox/list" do %>
         <%= render "components/combobox/group" do %>
-          <%= render "components/combobox/label" do %>Backend<% end %>
+          <%= render "components/combobox/label", text: "Backend" %>
           <%= render "components/combobox/option", value: "ruby" do %>Ruby<% end %>
           <%= render "components/combobox/option", value: "python" do %>Python<% end %>
           <%= render "components/combobox/option", value: "go" do %>Go<% end %>
@@ -16,7 +16,7 @@
         <%= render "components/combobox/separator" %>
 
         <%= render "components/combobox/group" do %>
-          <%= render "components/combobox/label" do %>Frontend<% end %>
+          <%= render "components/combobox/label", text: "Frontend" %>
           <%= render "components/combobox/option", value: "javascript" do %>JavaScript<% end %>
           <%= render "components/combobox/option", value: "typescript" do %>TypeScript<% end %>
         <% end %>

--- a/test/dummy/app/views/previews/index.html.erb
+++ b/test/dummy/app/views/previews/index.html.erb
@@ -31,12 +31,12 @@
   <div class="mt-8">
     <%= render "components/alert", variant: :default, icon: :info do %>
       <%= render "components/alert/title", text: "Query Parameters" %>
-      <%= render "components/alert/description" do %>
+      <%= render "components/alert/description", content: capture { %>
         <ul class="text-sm space-y-1 mt-2">
           <li><code class="bg-muted px-1 rounded">?theme=dark</code> - Enable dark mode</li>
           <li><code class="bg-muted px-1 rounded">?color_theme=blue</code> - Set color theme (neutral, green, rose, blue)</li>
         </ul>
-      <% end %>
+      <% } %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
This is a bug-fixing release addressing two categories of issues: Turbo Drive/Morph compatibility for the sidebar component, and a Rails partial rendering bug affecting block content in several components.

## Sidebar: Turbo Morph & Turbo Frame compatibility

### Problem
The sidebar broke when used with Turbo Morph (`turbo_refresh_method_tag :morph`) or inside replaced Turbo Frames. Two root causes:

1. Random IDs (`sidebar-#{SecureRandom.hex(6)}`) generated a different ID on every render, preventing idiomorph from matching old and new elements. This caused the entire `<aside>` subtree to be destroyed and recreated, triggering Stimulus disconnect/reconnect cycles, re-adding the `sidebar-loading` class, and losing all DOM state.

2. Morph overwrites controller-managed attributes. Even with matching elements, morph would set `data-sidebar-open-value` to the server-rendered value, triggering `openValueChanged()` which persisted stale state to the cookie (e.g., from broadcasts where cookies are unavailable).

### Changes
- Replace random IDs with deterministic `sidebar-#{side}` (produces `sidebar-left` or `sidebar-right`). Users with multiple sidebars on the same side can pass explicit `id:` parameters.
- Add stable `id` to sidebar provider (`sidebar-provider` by default).
- Add `turbo:before-morph-element` listener that sets a `_morphing` guard flag before idiomorph updates attributes.
- Guard `openValueChanged()` to skip `persistState()` during morph, preventing stale server values from overwriting the cookie.
- Enhance `handleMorph()` to read the cookie (client truth), reassert correct state, and remove the `sidebar-loading` class that morph re-adds from server HTML.

### Sidebar: Layout shift fix
- The server renders `collapsible="offcanvas"` which sets the sidebar gap to `width: 0`, but on desktop the Stimulus controller immediately changes it to `collapsible="none"` (`width: var(--sidebar-width)`), causing a visible jump where the main content shifts from left to right.
- Added a CSS rule scoped to `@media (min-width: 768px)` that overrides the gap width during the `sidebar-loading` phase when the sidebar state is `expanded`. This eliminates the layout shift before Stimulus initializes. The rule self-cleans when JS removes `sidebar-loading`.

## Partials: Replace yield with explicit content parameter

### Problem
In Rails, `yield` inside a partial always yields to the layout's content block when no explicit block is passed to `render`, and `block_given?` always returns `true` in the partial rendering context. This means `text || yield` silently renders the entire page content when only `text:` is provided (or neither), and `yield if block_given?` always executes.

### Changes
- Added `content: nil` parameter to 9 partials and replaced `yield` with `content`:
  - card/_title, card/_description
  - alert/_title, alert/_description
  - toast/_title, toast/_description
  - combobox/_label
  - _toast (replaced `yield if block_given?`)
  - _toaster (replaced `yield if block_given?`)
- Updated ToastHelper: removed `&block` from all 5 helper methods (`toast`, `toast_success`, `toast_error`, `toast_warning`, `toast_info`). The `content:` parameter flows through `**options`.
- Updated all dummy app references to use the new API.

## BREAKING CHANGES

### Block syntax no longer works for affected partials Before:
```erb
<%= render "components/card/description" do %>
  <p>Custom HTML</p>
<% end %>
```

After:
```erb
<%= render "components/card/description", content: capture { %>
  <p>Custom HTML</p>
<% } %>
```

Affected partials: card/title, card/description, alert/title, alert/description, toast/title, toast/description, combobox/label, toast (main), toaster.

The `text:` parameter for plain strings continues to work unchanged.

### Toast helper methods no longer accept blocks
Before:
```ruby
toast(:info, "Title") { render "components/toast/action", ... }
```

After:
```ruby
toast(:info, "Title", content: capture { render "components/toast/action", ... })
```

### Sidebar IDs are now deterministic
The sidebar `<aside>` ID changed from `sidebar-<random_hex>` to `sidebar-left` or `sidebar-right`. Users targeting the random ID format in CSS or JS must update their selectors. Users passing explicit `id:` parameters are unaffected.

### Sidebar provider now has an ID attribute
The provider div receives `id="sidebar-provider"` by default where previously it had none.

## Documentation updates
- docs/sidebar.md: Added sections on Stable IDs, Morph Compatibility, and Turbo Frames. Updated Provider API table with `id` parameter.
- docs/card.md, docs/alert.md: Updated API tables for title and description with `content` parameter.
- docs/toast.md: Updated API tables, added Toaster section with API reference, added Helper Methods table, updated With Action example.
- docs/combobox.md: Updated Label API table and examples.