### PR TITLE
 Fix: replace SVG `class` attribute (do not merge) and ensure classes are applied to SVGs without `class`

### DIFF
--- a/app/helpers/maquina_components/icons_helper.rb
+++ b/app/helpers/maquina_components/icons_helper.rb
@@ -26,8 +26,17 @@ module MaquinaComponents
     private
 
     def apply_icon_options(svg, options)
+      return svg.html_safe unless options&.any?
+
       css_classes = options[:class]
-      svg = svg.gsub('class="', "class=\"#{css_classes} ") if css_classes
+      if css_classes&.is_a?(String)
+        escaped_css_classes = ERB::Util.html_escape(css_classes)
+        svg = if /\bclass\s*=\s*(['"])(.*?)\1/.match?(svg)
+          svg.sub(/\bclass\s*=\s*(['"])(.*?)\1/, "class=\\1#{escaped_css_classes}\\1")
+        else
+          svg.sub(/<svg(?=(\s|>))/, "<svg class=\"#{escaped_css_classes}\"")
+        end
+      end
 
       if options[:stroke_width]
         svg = svg.gsub('stroke-width="2"', "stroke-width=\"#{options[:stroke_width]}\"")

--- a/test/dummy/app/helpers/application_helper.rb
+++ b/test/dummy/app/helpers/application_helper.rb
@@ -136,16 +136,10 @@ module ApplicationHelper
   #
   def icon_for(name, options = {})
     return nil unless name
-
     svg = app_icon_svg_for(name.to_sym) || icon_svg_for(name.to_sym)
     return nil unless svg
 
-    css_classes = options[:class]
-    svg = svg.gsub('class="', "class=\"#{css_classes} ") if css_classes.present?
-
-    svg = svg.gsub('stroke-width="2"', "stroke-width=\"#{options[:stroke_width]}\"") if options[:stroke_width]
-
-    svg.html_safe
+    apply_icon_options(svg, options)
   end
 
   # Application-specific icons. Add new icons here.
@@ -159,7 +153,7 @@ module ApplicationHelper
     case name
     when :sun
       <<~SVG
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="4"/>
           <path d="M12 2v2"/>
           <path d="M12 20v2"/>
@@ -173,7 +167,7 @@ module ApplicationHelper
       SVG
     when :moon
       <<~SVG
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
         </svg>
       SVG

--- a/test/helpers/icons_helper_test.rb
+++ b/test/helpers/icons_helper_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class IconsHelperTest < ActionView::TestCase
+  include MaquinaComponents::IconsHelper
+
+  test "adds class when svg has no class attribute" do
+    svg = '<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+    out = apply_icon_options(svg.dup, class: "foo-test")
+    assert_match(/class="foo-test"/, out)
+  end
+
+  test "does not merge classes when svg has existing class" do
+    svg = '<svg class="existing" xmlns="http://www.w3.org/2000/svg"></svg>'
+    out = apply_icon_options(svg.dup, class: "new-test")
+    assert_match(/class="new-test"/, out)
+    refute_match(/existing/, out)
+  end
+
+  test "handles class array and single/double quotes" do
+    svg_single = "<svg class='a' xmlns=\"http://www.w3.org/2000/svg\"></svg>"
+    out1 = apply_icon_options(svg_single.dup, class: "b c")
+    assert_match(/class='b c'/, out1)
+
+    svg_double = '<svg class="a" xmlns="http://www.w3.org/2000/svg"></svg>'
+    out2 = apply_icon_options(svg_double.dup, class: "b c")
+    assert_match(/class="b c"/, out2)
+  end
+end


### PR DESCRIPTION
**Overview:** The main issue was that SVGs without a `class` attribute were not receiving the requested classes. This PR ensures `apply_icon_options` replaces the `class` attribute (instead of merging) and inserts `class="..."` when missing. Array values are ignored — only strings are accepted.

**Problem (Before):**
- Unexpected merge: `class: "new"` on `<svg class="existing">` produced `class="new existing"`.
- Literal arrays: passing arrays or bracketed strings (e.g. `["b","c"]` or `"[b c]"`) inserted those literals into the `class` attribute.
- Inconsistent handling: the dummy app used a different insertion approach, causing differing behavior between app and engine.

**Solution (After):**
- Replace (not merge): when `options[:class]` is a string, replace any existing `class` value with that string (preserves single/double quotes).
- Insert when missing: if the SVG has no `class`, insert `class="..."` on the `<svg>` tag.
- Ignore arrays: if `options[:class]` is an array, do nothing; callers should pass a space-separated string (e.g. `"b c"`).
- Dummy app consistency: the dummy app now delegates to the engine helper so behavior matches.

**Examples**
- Before: `<svg class="existing">` + `class: "new"` → `<svg class="new existing">`  
- After: `<svg class="existing">` + `class: "new"` → `<svg class="new">`  
- Before: `class: ["b","c"]` → inserted literal `["b","c"]`  
- After: `class: ["b","c"]` → ignored; pass `class: "b c"`

**Files changed**
- icons_helper.rb  
- icons_helper_test.rb  
- application_helper.rb

**Tests**
- Added/updated helper tests. Run locally:
- `bin/test test/helpers/icons_helper_test.rb`
