### PR TITLE
Include engine helper modules in generated helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This will:
 - Add theme variables (light + dark mode)
 - Create a helper file for icon customization
 
+All engine helpers (`icon_for`, `sidebar_open?`, `toast_flash_messages`, etc.) are automatically available in your views without any additional configuration.
+
 ### 3. Use Components
 
 ```erb

--- a/lib/generators/maquina_components/install/templates/maquina_components_helper.rb.tt
+++ b/lib/generators/maquina_components/install/templates/maquina_components_helper.rb.tt
@@ -6,9 +6,16 @@
 # Override methods here to integrate with your application's icon system,
 # sidebar state management, and other customizations.
 #
+# Engine helper modules are included below to make their methods available
+# in your views (icon_for, sidebar_open?, toast_flash_messages, etc.).
+#
 # Documentation: https://github.com/maquina-app/maquina_components
 #
 module MaquinaComponentsHelper
+  include MaquinaComponents::IconsHelper
+  include MaquinaComponents::SidebarHelper
+  include MaquinaComponents::ToastHelper
+
   # Icon Override
   #
   # Override this method to use your own icon system (Heroicons, Lucide, etc.)

--- a/test/generators/install_generator_test.rb
+++ b/test/generators/install_generator_test.rb
@@ -142,6 +142,9 @@ class InstallGeneratorTest < Rails::Generators::TestCase
 
     assert_file "app/helpers/maquina_components_helper.rb" do |content|
       assert_match %r{module MaquinaComponentsHelper}, content
+      assert_match %r{include MaquinaComponents::IconsHelper}, content
+      assert_match %r{include MaquinaComponents::SidebarHelper}, content
+      assert_match %r{include MaquinaComponents::ToastHelper}, content
       assert_match %r{def main_icon_svg_for\(name\)}, content
       assert_match %r{def app_sidebar_state}, content
       assert_match %r{def app_sidebar_open\?}, content


### PR DESCRIPTION
## Summary
- Add `include` statements for `IconsHelper`, `SidebarHelper`, and `ToastHelper` in the generated helper template
- Add test assertions verifying the includes are present
- Add note in README about helper availability

Fixes #18

## Test plan
- `ruby -Itest test/generators/install_generator_test.rb` - all 14 tests pass (82 assertions)