### PR TITLE
Add scaffold_templates generator

### DIFF
--- a/lib/generators/maquina_components/scaffold_templates/scaffold_templates_generator.rb
+++ b/lib/generators/maquina_components/scaffold_templates/scaffold_templates_generator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails/generators/base"
+
+module MaquinaComponents
+  module Generators
+    class ScaffoldTemplatesGenerator < Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      desc "Copy maquina_components scaffold templates to your application"
+
+      TEMPLATE_FILES = %w[
+        _form.html.erb.tt
+        edit.html.erb.tt
+        index.html.erb.tt
+        new.html.erb.tt
+        partial.html.erb.tt
+        show.html.erb.tt
+      ].freeze
+
+      def copy_templates
+        TEMPLATE_FILES.each do |filename|
+          copy_file filename, "lib/templates/erb/scaffold/#{filename}"
+        end
+      end
+
+      def show_post_install_message
+        say ""
+        say "Scaffold templates installed!", :green
+        say ""
+        say "Rails will now use maquina_components when you run:"
+        say "  rails generate scaffold ModelName field:type"
+        say ""
+        say "Templates are in lib/templates/erb/scaffold/"
+        say "Feel free to customize them for your application."
+        say ""
+      end
+    end
+  end
+end

--- a/lib/generators/maquina_components/scaffold_templates/templates/_form.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/_form.html.erb.tt
@@ -1,0 +1,49 @@
+<%%= form_with(model: <%= model_resource_name %>, class: "space-y-4") do |form| %>
+  <%% if <%= singular_table_name %>.errors.any? %>
+    <%%= render "components/alert", variant: :destructive do %>
+      <%%= render "components/alert/title", text: "<%%= pluralize(<%= singular_table_name %>.errors.count, 'error') %> prohibited this <%= singular_table_name %> from being saved:" %>
+      <%%= render "components/alert/description" do %>
+        <ul class="list-disc list-inside mt-2">
+          <%% <%= singular_table_name %>.errors.each do |error| %>
+            <li><%%= error.full_message %></li>
+          <%% end %>
+        </ul>
+      <%% end %>
+    <%% end %>
+  <%% end %>
+
+<% attributes.each do |attribute| -%>
+  <div class="space-y-2">
+<% if attribute.password_digest? -%>
+    <%%= form.label :password %>
+    <%%= form.password_field :password, data: { component: "input" } %>
+  </div>
+
+  <div class="space-y-2">
+    <%%= form.label :password_confirmation %>
+    <%%= form.password_field :password_confirmation, data: { component: "input" } %>
+<% elsif attribute.attachments? -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, multiple: true, data: { component: "input" } %>
+<% elsif attribute.field_type == :text_area -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, data: { component: "textarea" } %>
+<% elsif attribute.field_type == :check_box -%>
+    <div class="flex items-center gap-2">
+      <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, data: { component: "checkbox" } %>
+      <%%= form.label :<%= attribute.column_name %> %>
+    </div>
+<% elsif attribute.field_type == :select -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, [], {}, data: { component: "select" } %>
+<% else -%>
+    <%%= form.label :<%= attribute.column_name %> %>
+    <%%= form.<%= attribute.field_type %> :<%= attribute.column_name %>, data: { component: "input" } %>
+<% end -%>
+  </div>
+
+<% end -%>
+  <div class="flex items-center gap-4 pt-4">
+    <%%= form.submit data: { component: "button", variant: "primary" } %>
+  </div>
+<%% end %>

--- a/lib/generators/maquina_components/scaffold_templates/templates/edit.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/edit.html.erb.tt
@@ -1,0 +1,29 @@
+<%% content_for :title, "Editing <%= human_name.downcase %>" %>
+
+<%% content_for :breadcrumbs do %>
+  <%%= render "components/breadcrumbs" do %>
+    <%%= render "components/breadcrumbs/list" do %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/link", href: <%= index_helper(type: :path) %>, text: "<%= human_name.pluralize %>" %>
+      <%% end %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/link", href: <%= model_resource_name(prefix: "@") %>, text: "<%= human_name %>" %>
+      <%% end %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/page", text: "Edit" %>
+      <%% end %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+
+<div class="space-y-6">
+  <%%= render "components/card" do %>
+    <%%= render "components/card/header" do %>
+      <%%= render "components/card/title", text: "Editing <%= human_name.downcase %>" %>
+    <%% end %>
+
+    <%%= render "components/card/content" do %>
+      <%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
+    <%% end %>
+  <%% end %>
+</div>

--- a/lib/generators/maquina_components/scaffold_templates/templates/index.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/index.html.erb.tt
@@ -1,0 +1,58 @@
+<%% content_for :title, "<%= human_name.pluralize %>" %>
+
+<div class="space-y-6">
+  <%%= render "components/card" do %>
+    <%%= render "components/card/header", layout: :row do %>
+      <div>
+        <%%= render "components/card/title", text: "<%= human_name.pluralize %>" %>
+        <%%= render "components/card/description", text: "<%%= @<%= plural_table_name %>.size %> record(s)" %>
+      </div>
+      <%%= render "components/card/action" do %>
+        <%%= link_to "New <%= human_name.downcase %>", <%= new_helper(type: :path) %>, data: { component: "button", variant: "primary", size: "sm" } %>
+      <%% end %>
+    <%% end %>
+
+    <%%= render "components/card/content" do %>
+      <%% if @<%= plural_table_name %>.any? %>
+        <%%= render "components/table" do %>
+          <%%= render "components/table/header" do %>
+            <%%= render "components/table/row" do %>
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+              <%%= render "components/table/head" do %><%= attribute.human_name %><%% end %>
+<% end -%>
+              <%%= render "components/table/head" do %><%% end %>
+            <%% end %>
+          <%% end %>
+          <%%= render "components/table/body" do %>
+            <%% @<%= plural_table_name %>.each do |<%= singular_table_name %>| %>
+              <%%= render "components/table/row" do %>
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+<% if attribute.attachment? -%>
+                <%%= render "components/table/cell" do %><%%= link_to <%= singular_table_name %>.<%= attribute.column_name %>.filename, <%= singular_table_name %>.<%= attribute.column_name %> if <%= singular_table_name %>.<%= attribute.column_name %>.attached? %><%% end %>
+<% elsif attribute.attachments? -%>
+                <%%= render "components/table/cell" do %><%%= <%= singular_table_name %>.<%= attribute.column_name %>.count %> file(s)<%% end %>
+<% else -%>
+                <%%= render "components/table/cell" do %><%%= <%= singular_table_name %>.<%= attribute.column_name %> %><%% end %>
+<% end -%>
+<% end -%>
+                <%%= render "components/table/cell" do %>
+                  <%%= link_to "Show this <%= human_name.downcase %>", <%= model_resource_name(singular_table_name) %>, data: { component: "button", variant: "ghost", size: "sm" } %>
+                <%% end %>
+              <%% end %>
+            <%% end %>
+          <%% end %>
+        <%% end %>
+      <%% else %>
+        <%%= render "components/empty" do %>
+          <%%= render "components/empty/header" do %>
+            <%%= render "components/empty/title", text: "No <%= human_name.pluralize.downcase %> yet" %>
+            <%%= render "components/empty/description", text: "Get started by creating a new <%= human_name.downcase %>." %>
+          <%% end %>
+          <%%= render "components/empty/content" do %>
+            <%%= link_to "New <%= human_name.downcase %>", <%= new_helper(type: :path) %>, data: { component: "button", variant: "primary" } %>
+          <%% end %>
+        <%% end %>
+      <%% end %>
+    <%% end %>
+  <%% end %>
+</div>

--- a/lib/generators/maquina_components/scaffold_templates/templates/new.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/new.html.erb.tt
@@ -1,0 +1,26 @@
+<%% content_for :title, "New <%= human_name.downcase %>" %>
+
+<%% content_for :breadcrumbs do %>
+  <%%= render "components/breadcrumbs" do %>
+    <%%= render "components/breadcrumbs/list" do %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/link", href: <%= index_helper(type: :path) %>, text: "<%= human_name.pluralize %>" %>
+      <%% end %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/page", text: "New" %>
+      <%% end %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+
+<div class="space-y-6">
+  <%%= render "components/card" do %>
+    <%%= render "components/card/header" do %>
+      <%%= render "components/card/title", text: "New <%= human_name.downcase %>" %>
+    <%% end %>
+
+    <%%= render "components/card/content" do %>
+      <%%= render "form", <%= singular_table_name %>: @<%= singular_table_name %> %>
+    <%% end %>
+  <%% end %>
+</div>

--- a/lib/generators/maquina_components/scaffold_templates/templates/partial.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/partial.html.erb.tt
@@ -1,0 +1,17 @@
+<div id="<%%= dom_id <%= singular_name %> %>">
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+  <div>
+    <strong class="text-sm font-medium text-muted-foreground"><%= attribute.human_name %>:</strong>
+<% if attribute.attachment? -%>
+    <%%= link_to <%= singular_name %>.<%= attribute.column_name %>.filename, <%= singular_name %>.<%= attribute.column_name %> if <%= singular_name %>.<%= attribute.column_name %>.attached? %>
+<% elsif attribute.attachments? -%>
+    <%% <%= singular_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
+      <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
+    <%% end %>
+<% else -%>
+    <%%= <%= singular_name %>.<%= attribute.column_name %> %>
+<% end -%>
+  </div>
+
+<% end -%>
+</div>

--- a/lib/generators/maquina_components/scaffold_templates/templates/show.html.erb.tt
+++ b/lib/generators/maquina_components/scaffold_templates/templates/show.html.erb.tt
@@ -1,0 +1,53 @@
+<%% content_for :title, "<%= human_name %>" %>
+
+<%% content_for :breadcrumbs do %>
+  <%%= render "components/breadcrumbs" do %>
+    <%%= render "components/breadcrumbs/list" do %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/link", href: <%= index_helper(type: :path) %>, text: "<%= human_name.pluralize %>" %>
+      <%% end %>
+      <%%= render "components/breadcrumbs/item" do %>
+        <%%= render "components/breadcrumbs/page", text: "<%= human_name %>" %>
+      <%% end %>
+    <%% end %>
+  <%% end %>
+<%% end %>
+
+<div class="space-y-6">
+  <%%= render "components/card" do %>
+    <%%= render "components/card/header", layout: :row do %>
+      <div>
+        <%%= render "components/card/title", text: "<%= human_name %>" %>
+      </div>
+      <%%= render "components/card/action" do %>
+        <%%= link_to "Edit this <%= human_name.downcase %>", <%= edit_helper(type: :path) %>, data: { component: "button", variant: "outline", size: "sm" } %>
+      <%% end %>
+    <%% end %>
+
+    <%%= render "components/card/content" do %>
+      <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+<% attributes.reject(&:password_digest?).each do |attribute| -%>
+        <div>
+          <dt class="text-sm font-medium text-muted-foreground"><%= attribute.human_name %></dt>
+<% if attribute.attachment? -%>
+          <dd class="mt-1"><%%= link_to @<%= singular_table_name %>.<%= attribute.column_name %>.filename, @<%= singular_table_name %>.<%= attribute.column_name %> if @<%= singular_table_name %>.<%= attribute.column_name %>.attached? %></dd>
+<% elsif attribute.attachments? -%>
+          <dd class="mt-1">
+            <%% @<%= singular_table_name %>.<%= attribute.column_name %>.each do |<%= attribute.singular_name %>| %>
+              <div><%%= link_to <%= attribute.singular_name %>.filename, <%= attribute.singular_name %> %></div>
+            <%% end %>
+          </dd>
+<% else -%>
+          <dd class="mt-1"><%%= @<%= singular_table_name %>.<%= attribute.column_name %> %></dd>
+<% end -%>
+        </div>
+<% end -%>
+      </dl>
+    <%% end %>
+
+    <%%= render "components/card/footer" do %>
+      <%%= link_to "Back to <%= human_name.pluralize.downcase %>", <%= index_helper(type: :path) %>, data: { component: "button", variant: "ghost" } %>
+      <%%= button_to "Destroy this <%= human_name.downcase %>", <%= model_resource_name(prefix: "@") %>, method: :delete, data: { component: "button", variant: "destructive" } %>
+    <%% end %>
+  <%% end %>
+</div>

--- a/test/generators/scaffold_templates_generator_test.rb
+++ b/test/generators/scaffold_templates_generator_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+require "rails/generators/test_case"
+require "generators/maquina_components/scaffold_templates/scaffold_templates_generator"
+
+class ScaffoldTemplatesGeneratorTest < Rails::Generators::TestCase
+  tests MaquinaComponents::Generators::ScaffoldTemplatesGenerator
+  destination File.expand_path("../tmp", __dir__)
+
+  setup do
+    prepare_destination
+  end
+
+  teardown do
+    FileUtils.rm_rf(destination_root)
+  end
+
+  test "copies all scaffold template files" do
+    run_generator
+
+    %w[_form edit index new partial show].each do |name|
+      assert_file "lib/templates/erb/scaffold/#{name}.html.erb.tt"
+    end
+  end
+
+  test "index template uses card and table components" do
+    run_generator
+
+    assert_file "lib/templates/erb/scaffold/index.html.erb.tt" do |content|
+      assert_match %r{render "components/card"}, content
+      assert_match %r{render "components/table"}, content
+      assert_match %r{render "components/empty"}, content
+      assert_match %r{data: \{ component: "button", variant: "primary"}, content
+    end
+  end
+
+  test "form template uses component data attributes" do
+    run_generator
+
+    assert_file "lib/templates/erb/scaffold/_form.html.erb.tt" do |content|
+      assert_match %r{data: \{ component: "input" \}}, content
+      assert_match %r{data: \{ component: "textarea" \}}, content
+      assert_match %r{data: \{ component: "checkbox" \}}, content
+      assert_match %r{render "components/alert"}, content
+    end
+  end
+
+  test "show template uses breadcrumbs and card components" do
+    run_generator
+
+    assert_file "lib/templates/erb/scaffold/show.html.erb.tt" do |content|
+      assert_match %r{render "components/breadcrumbs"}, content
+      assert_match %r{render "components/card"}, content
+      assert_match %r{render "components/card/footer"}, content
+      assert_match %r{variant: "destructive"}, content
+    end
+  end
+
+  test "new and edit templates use breadcrumbs" do
+    run_generator
+
+    assert_file "lib/templates/erb/scaffold/new.html.erb.tt" do |content|
+      assert_match %r{render "components/breadcrumbs"}, content
+      assert_match %r{content_for :breadcrumbs}, content
+    end
+
+    assert_file "lib/templates/erb/scaffold/edit.html.erb.tt" do |content|
+      assert_match %r{render "components/breadcrumbs"}, content
+      assert_match %r{content_for :breadcrumbs}, content
+    end
+  end
+
+  test "templates use English text matching Rails conventions" do
+    run_generator
+
+    assert_file "lib/templates/erb/scaffold/show.html.erb.tt" do |content|
+      assert_match %r{Destroy this}, content
+      assert_match %r{Back to}, content
+    end
+
+    assert_file "lib/templates/erb/scaffold/index.html.erb.tt" do |content|
+      assert_match %r{Show this}, content
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `scaffold_templates` generator so users can opt-in to maquina_components-styled scaffold views:

```bash
rails generate maquina_components:scaffold_templates
```

This copies 6 ERB templates to `lib/templates/erb/scaffold/`, so any subsequent `rails generate scaffold` produces views using card, table, breadcrumbs, alert, and empty state components with `data-component` attributes on form elements.

The templates follow the same English text conventions as Rails defaults ("New product", "Destroy this product", "Back to products", etc.), just wrapped in maquina_components markup.

## What's included

- `scaffold_templates_generator.rb` - copies templates to the host app
- 6 templates: `_form`, `index`, `show`, `new`, `edit`, `partial`
- Test coverage (6 tests, 58 assertions)

## A note

I just started using maquina_components for the first time this week. If this contribution feels too early or the templates don't align with the direction you have in mind for the project, feel free to close this PR. I found myself creating these templates anyway after installing the gem, and thought they might be useful for other users getting started.

## Test plan

```bash
ruby -Itest test/generators/scaffold_templates_generator_test.rb
# 6 runs, 58 assertions, 0 failures
```