### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-07-12
+
+### Added
+
+- Add Drawer component with trigger and keyboard shortcut support (#21)
+  - Slide-out panel with `provider`, `header`, `content`, `footer`, `trigger`, and `close` sub-partials; left/right side, overlay backdrop, cookie persistence
+  - `Cmd/Ctrl+D` keyboard shortcut and full Turbo Drive/Morph compatibility
+  - `drawer_state`, `drawer_open?`, `drawer_closed?` helpers; `docs/drawer.md`
+- Add `scaffold_templates` generator (#20)
+  - `rails g maquina_components:scaffold_templates` copies ERB scaffold templates to `lib/templates/erb/scaffold/` so `rails g scaffold` produces maquina_components-styled views (index, show, new, edit, _form, partial)
+- Include engine helper modules in the generated helper template (#19)
+  - `MaquinaComponentsHelper` now includes `IconsHelper`, `SidebarHelper`, and `ToastHelper`, so `icon_for`, `sidebar_open?`, `toast_flash_messages`, etc. are available in host-app views without extra configuration
+
+### Fixed
+
+- Improve icon class handling in `apply_icon_options` (#17)
+  - Guard against nil options and non-string `class` values; HTML-escape classes
+  - Inject a `class` attribute on `<svg>` elements that don't already have one
+
+### Contributors
+
+Thanks to the contributors who made this release possible:
+
+- [@GregorioNeto](https://github.com/GregorioNeto) — Drawer component (#21), icon class handling (#17)
+- [@JuanVqz](https://github.com/JuanVqz) — scaffold_templates generator (#20), engine helper modules in generated helper (#19)
+
 ## [0.4.4] - 2026-03-09
 
 ### Added
@@ -210,7 +236,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rails Engine structure
 - Basic TailwindCSS integration
 
-[Unreleased]: https://github.com/maquina-app/maquina_components/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/maquina-app/maquina_components/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/maquina-app/maquina_components/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/maquina-app/maquina_components/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/maquina-app/maquina_components/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/maquina-app/maquina_components/compare/v0.4.1...v0.4.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    maquina-components (0.4.4)
+    maquina-components (0.5.0)
       rails (>= 7.2.0)
       tailwindcss-rails (~> 4.2)
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ bin/rails generate maquina_components:install --skip-theme
 bin/rails generate maquina_components:install --skip-helper
 ```
 
+### Scaffold Templates
+
+Copy ERB scaffold templates into your application so Rails' built-in `scaffold`
+generator produces maquina_components-styled views:
+
+```bash
+bin/rails generate maquina_components:scaffold_templates
+```
+
+This installs `index`, `show`, `new`, `edit`, `_form`, and partial templates to
+`lib/templates/erb/scaffold/`. After running it, `rails generate scaffold ModelName field:type`
+generates views built with maquina_components. Customize the templates as needed.
+
 **Prerequisite:** [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) must be installed first.
 
 ---
@@ -157,6 +170,7 @@ bin/rails generate maquina_components:install --skip-helper
 | **Calendar** | Inline date picker with single/range selection | [Calendar](https://maquina.app/documentation/components/calendar/) |
 | **Combobox** | Searchable dropdown with keyboard navigation | [Combobox](https://maquina.app/documentation/components/combobox/) |
 | **Date Picker** | Popover-based date selection | [Date Picker](https://maquina.app/documentation/components/date-picker/) |
+| **Drawer** | Slide-out panel with overlay and keyboard shortcut | [Drawer](https://maquina.app/documentation/components/drawer/) |
 | **Toggle Group** | Single/multiple selection button group | [Toggle Group](https://maquina.app/documentation/components/toggle-group/) |
 
 ### Feedback Components

--- a/lib/maquina_components/version.rb
+++ b/lib/maquina_components/version.rb
@@ -1,3 +1,3 @@
 module MaquinaComponents
-  VERSION = "0.4.4"
+  VERSION = "0.5.0"
 end

--- a/test/dummy/app/views/previews/drawer/default.html.erb
+++ b/test/dummy/app/views/previews/drawer/default.html.erb
@@ -1,0 +1,46 @@
+<%= preview_container width: :md do %>
+  <p class="text-sm text-muted-foreground mb-4">
+    Click the button below or press <kbd class="kbd">CTRL</kbd> +
+    <kbd class="kbd">D</kbd> to open the drawer.
+  </p>
+
+  <%= render "components/drawer/provider", default_open: false, keyboard_shortcut: "d" do %>
+    <%= render "components/drawer/trigger", icon_name: :panel_left do %>
+      Open Drawer
+    <% end %>
+
+    <%= render "components/drawer", id: "drawer", state: :closed, side: :right do %>
+      <%= render "components/drawer/header" do %>
+        <h3 class="text-lg font-semibold">Drawer Title</h3>
+        <p class="text-sm text-muted-foreground">Slide-out panel example</p>
+      <% end %>
+
+      <%= render "components/drawer/content" do %>
+        <div class="space-y-4">
+          <p class="text-sm">
+            This is a drawer component that slides in from the right side of the
+            screen. It provides additional content without leaving the current page.
+          </p>
+          <div class="space-y-2">
+            <p class="text-sm font-medium">Features:</p>
+            <ul class="text-sm text-muted-foreground list-disc pl-4 space-y-1">
+              <li>Keyboard shortcut support (CTRL + D)</li>
+              <li>Cookie state persistence</li>
+              <li>Backdrop click to close</li>
+              <li>Escape key to close</li>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+
+      <%= render "components/drawer/footer" do %>
+        <%= render "components/drawer/close", show_icon: false, variant: :outline do %>
+          Cancel
+        <% end %>
+        <button type="button" data-component="button" data-variant="default">
+          Save Changes
+        </button>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/test/dummy/app/views/previews/drawer/left_side.html.erb
+++ b/test/dummy/app/views/previews/drawer/left_side.html.erb
@@ -1,0 +1,31 @@
+<%= preview_container width: :md do %>
+  <p class="text-sm text-muted-foreground mb-4">
+    A drawer that slides in from the left side of the screen.
+  </p>
+
+  <%= render "components/drawer/provider", default_open: false, keyboard_shortcut: "d" do %>
+    <%= render "components/drawer/trigger", icon_name: :panel_left do %>
+      Open Left Drawer
+    <% end %>
+
+    <%= render "components/drawer", id: "drawer-left", state: :closed, side: :left do %>
+      <%= render "components/drawer/header" do %>
+        <h3 class="text-lg font-semibold">Left Drawer</h3>
+        <p class="text-sm text-muted-foreground">Positioned on the left</p>
+      <% end %>
+
+      <%= render "components/drawer/content" do %>
+        <p class="text-sm">
+          Set <code class="text-xs">side: :left</code> on the drawer partial to
+          slide the panel in from the left edge of the screen.
+        </p>
+      <% end %>
+
+      <%= render "components/drawer/footer" do %>
+        <%= render "components/drawer/close", show_icon: false, variant: :outline do %>
+          Close
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Prepares the **v0.5.0** release, recording everything merged since `v0.4.4`.

## Changes

- **Version bump** to `0.5.0` (`lib/maquina_components/version.rb`, `Gemfile.lock`)
- **CHANGELOG.md** — new `## [0.5.0]` section covering:
  - Drawer component (#21)
  - `scaffold_templates` generator (#20)
  - engine helper modules in the generated helper template (#19)
  - icon class handling fix in `apply_icon_options` (#17)
  - Contributors credit + updated compare links
- **README.md** — Drawer row in the Interactive Components table and a Scaffold Templates section under Generator Options
- **Dummy app previews** — new isolated previews `previews/drawer/default` and `previews/drawer/left_side` (auto-registered via `PreviewRegistry`)

## Verification

- `MaquinaComponents::VERSION` → `0.5.0`
- Booted the dummy app: both drawer previews return HTTP 200, render the drawer / drawer-trigger Stimulus controllers, and the left variant emits `data-side="left"`; home page still 200
- Tests green: icons helper (3 runs), scaffold generator (6 runs), install generator (14 runs) — 0 failures

## Contributors

- @GregorioNeto — Drawer component (#21), icon class handling (#17)
- @JuanVqz — scaffold_templates generator (#20), engine helper modules (#19)